### PR TITLE
fix: use more explicity return statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,8 @@ export default function init({ app, mappings, host, claimsCheck }) {
         Make sure you authorize your request by providing the following HTTP header:
         Authorization: Bearer <Firebase Access Token>`;
       functions.logger.error(errorMessage);
-      response.status(403).send(errorMessage);
 
-      return;
+      return response.status(403).send(errorMessage);
     }
 
     const idToken = request.headers.authorization.split('Bearer ')[1];
@@ -98,18 +97,16 @@ export default function init({ app, mappings, host, claimsCheck }) {
 
       if (!claimsCheck || claimsCheck(decodedIdToken)) {
         request.user = decodedIdToken;
-        next();
-      } else {
-        response.status(403).send('Unauthorized: claims check failed');
+
+        return next();
       }
 
-      return;
+      return response.status(403).send('Unauthorized: claims check failed');
     } catch (error) {
       const errorMessage = 'Error while verifying Firebase access token';
       functions.logger.error(errorMessage, error);
-      response.status(403).send(errorMessage);
 
-      return;
+      return response.status(403).send(errorMessage);
     }
   };
 


### PR DESCRIPTION
I was having an issue with electrofishing functions hanging when running in the emulators. It caused me to take a closer look at the return statements in this project. Although, this wasn't the fix to my specific problem (it was a memory issue), I do think that this is an improvement.